### PR TITLE
Allow the developer to create multiple links

### DIFF
--- a/PhpTube.php
+++ b/PhpTube.php
@@ -66,6 +66,13 @@ class PhpTube
         return $videoUrls;
     }
     
+    /**
+     * Parses the YouTube URL's and return them back to the developer
+     * 
+     * @param  $watchUrls the URLs of the Youtube video's
+     * @return array|array the error message or the array of download links
+     */
+    
     public function getDownloadLinks(array $watchUrls = array())
     {
         // Loops throught the url and return a array which contains all of the converted links

--- a/PhpTube.php
+++ b/PhpTube.php
@@ -65,6 +65,20 @@ class PhpTube
 
         return $videoUrls;
     }
+    
+    public function getDownloadLinks(array $watchUrls = array())
+    {
+        // Loops throught the url and return a array which contains all of the converted links
+        
+        $converted = array();
+        
+        foreach ($watchUrls as $watchUrl)
+        {
+            $converted[] = $this->getDownloadLink($watchUrl); 
+        }
+        
+        return $converted;
+    }
 
     /**
      * A wrapper around the cURL library to fetch the content of the url


### PR DESCRIPTION
This small fix allows the developer to pass an array to the getDownloadLinks() method and get an array back with all of his passed in links.
